### PR TITLE
fix: 修复PayloadTooLargeError: request entity too large导致的无法保存插件配置文件

### DIFF
--- a/framework/src/loader/loadPreload.js
+++ b/framework/src/loader/loadPreload.js
@@ -3,12 +3,17 @@ import path from 'path'
 import chalk from 'chalk'
 import {Preload} from "../../index.js";
 import {loadClass} from "../utils/common.js";
+import bodyParser from 'body-parser';  // 添加 body-parser 导入
 
 /**
  * 依次创建页面预加载
  * @param {GuobaApplication} guobaApp
  */
 export async function usePreload(guobaApp) {
+  // 添加 body-parser 配置
+  guobaApp.app.use(bodyParser.json({limit: '50mb'}));
+  guobaApp.app.use(bodyParser.urlencoded({limit: '50mb', extended: true}));
+
   const {_args: {preloads}} = guobaApp
   for (const item of preloads) {
     await hookAppPreloads(guobaApp, item)


### PR DESCRIPTION
具体报错如下:
```
PayloadTooLargeError: request entity too large
    at readStream (E:\miao\Yunzai-Bot\node_modules\.pnpm\raw-body@2.5.2\node_modules\raw-body\index.js:163:17)
    at getRawBody (E:\miao\Yunzai-Bot\node_modules\.pnpm\raw-body@2.5.2\node_modules\raw-body\index.js:116:12)
    at read (E:\miao\Yunzai-Bot\node_modules\.pnpm\body-parser@1.20.3\node_modules\body-parser\lib\read.js:79:3)
    at jsonParser (E:\miao\Yunzai-Bot\node_modules\.pnpm\body-parser@1.20.3\node_modules\body-parser\lib\types\json.js:138:5)
    at Layer.handle [as handle_request] (E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\layer.js:95:5)
    at trim_prefix (E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\index.js:328:13)
    at E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\index.js:286:9
    at Function.process_params (E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\index.js:346:12)
    at next (E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\index.js:280:10)
    at serveStatic (E:\miao\Yunzai-Bot\node_modules\.pnpm\serve-static@1.16.2\node_modules\serve-static\index.js:75:16)
    at Layer.handle [as handle_request] (E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\layer.js:95:5)
    at trim_prefix (E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\index.js:328:13)
    at E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\index.js:286:9
    at Function.process_params (E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\index.js:346:12)
    at next (E:\miao\Yunzai-Bot\node_modules\.pnpm\express@4.21.1\node_modules\express\lib\router\index.js:280:10)
    at file:///E:/miao/Yunzai-Bot/plugins/Guoba-Plugin/framework/src/loader/loadPreload.js:48:7
```
复现的话，当保存的插件配置文件大小超过90kb，即报这个错，也无法保存插件配置文件，只能手动打开对应的插件配置文件进行修改