### PR TITLE
喜报: 又一个高危漏洞

### DIFF
--- a/server/controller/HelperController.js
+++ b/server/controller/HelperController.js
@@ -1,5 +1,6 @@
 import {autowired, Result} from '#guoba.framework'
 import {ApiController, cfg} from '#guoba.platform'
+import net from 'net'
 
 const RedisDecorator = await Guoba.GID('#/decorator/RedisDecorator.js')
 
@@ -50,7 +51,7 @@ export default class HelperController extends ApiController {
   }
 
   tryReleasePort(req) {
-    if (req.hostname !== 'localhost') {
+    if (!isLoopbackAddress(req.socket?.remoteAddress)) {
       return Result.noAuth()
     }
     logger.mark('[Guoba] 服务已在另一处启动，正在尝试停止当前服务……')
@@ -66,4 +67,22 @@ export default class HelperController extends ApiController {
     }, 10)
     return Result.ok()
   }
+}
+
+function isLoopbackAddress(address) {
+  if (typeof address !== 'string' || address.length === 0) {
+    return false
+  }
+
+  const normalized = address.replace(/^\[|\]$/g, '').toLowerCase()
+  if (normalized === '::1' || normalized === '0:0:0:0:0:0:0:1') {
+    return true
+  }
+  if (normalized.startsWith('::ffff:')) {
+    return isLoopbackAddress(normalized.substring(7))
+  }
+  if (!net.isIPv4(normalized)) {
+    return false
+  }
+  return normalized.split('.')[0] === '127'
 }


### PR DESCRIPTION
## 修复内容

`/api/helper/release_port` 原本通过 `req.hostname === 'localhost'` 判断是否为本机请求，但 `req.hostname` 会受 HTTP `Host` 头影响。外部请求伪造 `Host: localhost` 时，可能绕过校验并触发 `Guoba.server.close()`，造成未登录关闭 Web 服务。

本 PR 将该判断改为校验真实连接来源 `req.socket.remoteAddress`，只允许 loopback 地址访问：

- `127.0.0.0/8`
- `::1`
- `::ffff:127.x.x.x`

## 影响范围

漏洞自 2022 年 9 月引入，起始提交为：

- [`c5a1aa3147e61b5986f89b383c11cb5cf41b5e16`](https://github.com/guoba-yunzai/guoba-plugin/commit/c5a1aa3147e61b5986f89b383c11cb5cf41b5e16)，2022-09-18 16:31:34 +08:00，`新增端口号被占用提示`
- Gitee 同提交链接：[`c5a1aa3147e61b5986f89b383c11cb5cf41b5e16`](https://gitee.com/guoba-yunzai/guoba-plugin/commit/c5a1aa3147e61b5986f89b383c11cb5cf41b5e16)

该提交同时新增了 `/api/helper/release_port`、将其加入 `TokenInterceptor` 鉴权排除列表，并使用 `req.hostname !== 'localhost'` 作为访问来源校验。父提交及更早历史中不存在该接口，因此不受此漏洞影响。

仓库当前没有 Git tag 可用于精确映射发布版本；按提交历史判断，所有包含 `c5a1aa3` 且未应用本修复的分支、源码包或构建均受影响。已确认 GitHub 上游 `master` 与 Gitee `master/dev` 当前均指向 `4a7ca24`（2026-06-29），且仍保留旧的 `req.hostname` 校验，因此影响范围延续到当前同步后的 `master/dev`。

## 验证

- `node --check server/controller/HelperController.js`
- 本地最小靶场验证：普通 Host 返回 403，伪造 `Host: localhost` 命中旧逻辑；修复后不再信任 Host 头。

## 影响

正常的本机端口释放流程仍可通过 `localhost` 发起，因为真实远端地址是 loopback；远程伪造 Host 头不再能通过校验。